### PR TITLE
udev rules file

### DIFF
--- a/90-posbox.rules
+++ b/90-posbox.rules
@@ -1,0 +1,5 @@
+# /etc/udev/rules.d/90-posbox.rules
+#Printer Bematech MP-4200 TH
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0b1b", ATTRS{idProduct}=="0003", SYMLINK+="printer_MP4200TH"
+ACTION=="remove",  SUBSYSTEM=="tty", ATTRS{idVendor}=="0b1b", ATTRS{idProduct}=="0003", SYMLINK+="printer_MP4200TH"
+


### PR DESCRIPTION
Arquivo de regras udev a ser colocado em

/etc/udev/rules.d/

Para criar symlinks com nomes fixos para dispositivos.

Atualmente contem regra para impressora térmica:

Bematech MP-4200 TH